### PR TITLE
freelist: read all free pages on count overflow

### DIFF
--- a/freelist.go
+++ b/freelist.go
@@ -245,7 +245,7 @@ func (f *freelist) read(p *page) {
 	if count == 0 {
 		f.ids = nil
 	} else {
-		ids := ((*[maxAllocSize]pgid)(unsafe.Pointer(&p.ptr)))[idx:count]
+		ids := ((*[maxAllocSize]pgid)(unsafe.Pointer(&p.ptr)))[idx:idx+count]
 		f.ids = make([]pgid, len(ids))
 		copy(f.ids, ids)
 


### PR DESCRIPTION
count is not shifted up by start index when taking subslice of free
list, dropping the last entry in the list.