### PR TITLE
test: use qconfig() instead of defaults in TestBucket_Put_Single

### DIFF
--- a/bucket_test.go
+++ b/bucket_test.go
@@ -1640,7 +1640,7 @@ func TestBucket_Put_Single(t *testing.T) {
 
 		index++
 		return true
-	}, nil); err != nil {
+	}, qconfig()); err != nil {
 		t.Error(err)
 	}
 }


### PR DESCRIPTION
Default/nil quick.Config uses 1000 rounds, causing TestBucker_Put_Single to
run for over 3 minutes in CI. The default count (via qconfig()) for boltdb
is 5, so use that.