### PR TITLE
Fix deletion of non-existing keys

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -323,7 +323,12 @@ func (b *Bucket) Delete(key []byte) error {
 
 	// Move cursor to correct position.
 	c := b.Cursor()
-	_, _, flags := c.seek(key)
+	k, _, flags := c.seek(key)
+
+	// Return nil if the key doesn't exist.
+	if !bytes.Equal(key, k) {
+		return nil
+	}
 
 	// Return an error if there is already existing bucket value.
 	if (flags & bucketLeafFlag) != 0 {


### PR DESCRIPTION
via https://github.com/boltdb/bolt/pull/660; looks important

Change Bucket.Delete to do what its doc comment says in a case of non-existing keys, e.g. nothing.
This pull request fixes boltdb#349