### PR TITLE
Added support for no timeout locks on db files

### DIFF
--- a/bolt_unix_solaris.go
+++ b/bolt_unix_solaris.go
@@ -13,12 +13,13 @@ import (
 // flock acquires an advisory lock on a file descriptor.
 func flock(f *os.File, exclusive bool, timeout time.Duration) error {
 	var t time.Time
+	if timeout > 0 {
+		t = time.Now()
+	}
 	for {
 		// If we're beyond our timeout then return an error.
 		// This can only occur after we've attempted a flock once.
-		if t.IsZero() {
-			t = time.Now()
-		} else if timeout > 0 && time.Since(t) > timeout {
+		if timeout > 0 && time.Since(t) > timeout {
 			return ErrTimeout
 		}
 		var lock syscall.Flock_t
@@ -35,7 +36,11 @@ func flock(f *os.File, exclusive bool, timeout time.Duration) error {
 		err := syscall.FcntlFlock(f.Fd(), syscall.F_SETLK, &lock)
 		if err == nil {
 			return nil
-		} else if err != syscall.EAGAIN {
+		} else if err == syscall.EAGAIN {
+			if timeout < 0 {
+				return ErrTimeout
+			}
+		} else {
 			return err
 		}
 

--- a/bolt_windows.go
+++ b/bolt_windows.go
@@ -48,12 +48,13 @@ func fdatasync(db *DB) error {
 // flock acquires an advisory lock on a file descriptor.
 func flock(f *os.File, exclusive bool, timeout time.Duration) error {
 	var t time.Time
+	if timeout > 0 {
+		t = time.Now()
+	}
 	for {
 		// If we're beyond our timeout then return an error.
 		// This can only occur after we've attempted a flock once.
-		if t.IsZero() {
-			t = time.Now()
-		} else if timeout > 0 && time.Since(t) > timeout {
+		if timeout > 0 && time.Since(t) > timeout {
 			return ErrTimeout
 		}
 
@@ -65,7 +66,11 @@ func flock(f *os.File, exclusive bool, timeout time.Duration) error {
 		err := lockFileEx(syscall.Handle(f.Fd()), flag, 0, 1, 0, &syscall.Overlapped{})
 		if err == nil {
 			return nil
-		} else if err != errLockViolation {
+		} else if err == errLockViolation {
+			if timeout < 0 {
+				return ErrTimeout
+			}
+		} else {
 			return err
 		}
 

--- a/db.go
+++ b/db.go
@@ -843,8 +843,9 @@ func (db *DB) IsReadOnly() bool {
 // Options represents the options that can be set when opening a database.
 type Options struct {
 	// Timeout is the amount of time to wait to obtain a file lock.
-	// When set to zero it will wait indefinitely. This option is only
-	// available on Darwin and Linux.
+	// When set to zero it will wait indefinitely. When set to a negative
+	// duration, it will fail immediately if the file is already locked.
+	// This option is only available on Darwin and Linux.
 	Timeout time.Duration
 
 	// Sets the DB.NoGrowSync flag before memory mapping the file.


### PR DESCRIPTION
Pull request has been added to boltdb/bolt (#494) but has been queued for processing.

So I submit it there in the hope that it can be merged into a reasonably maintained repo so I dont have anymore to maintain a separate repo on the side.

Beside my application needs, I think this change is beneficial to the community as it completes the timeout locking API which didn't support an obvious case (failing right away if the database lock file can not be acquired instead of having to wait a given duration). I took the opportunity to refactor slightly these few lines of code to make them cleaner.

Full discussion of the initial boltdb/bolt pull request is there:
https://github.com/boltdb/bolt/pull/494