### PR TITLE
Added support for no timeout locks on db files

### DIFF
--- a/bolt_unix.go
+++ b/bolt_unix.go
@@ -12,30 +12,34 @@ import (
 
 // flock acquires an advisory lock on a file descriptor.
 func flock(db *DB, mode os.FileMode, exclusive bool, timeout time.Duration) error {
+	maxSleep := timeout - timeoutStep
 	var t time.Time
+	if maxSleep >= 0 {
+	        t = time.Now()
+	}
+	fd := db.file.Fd()
+	flag := syscall.LOCK_NB
+	if exclusive {
+		flag |= syscall.LOCK_EX
+	} else {
+		flag |= syscall.LOCK_SH 
+	}
 	for {
-		// If we're beyond our timeout then return an error.
-		// This can only occur after we've attempted a flock once.
-		if t.IsZero() {
-			t = time.Now()
-		} else if timeout > 0 && time.Since(t) > timeout {
-			return ErrTimeout
-		}
-		flag := syscall.LOCK_SH
-		if exclusive {
-			flag = syscall.LOCK_EX
-		}
-
-		// Otherwise attempt to obtain an exclusive lock.
-		err := syscall.Flock(int(db.file.Fd()), flag|syscall.LOCK_NB)
+		// Attempt to obtain an exclusive lock.
+		err := syscall.Flock(int(fd), flag)
 		if err == nil {
 			return nil
 		} else if err != syscall.EWOULDBLOCK {
 			return err
 		}
 
+		// If we timed out then return an error.
+		if timeout != 0 && (maxSleep < 0 || time.Since(t) > maxSleep) {
+			return ErrTimeout
+		}
+
 		// Wait for a bit and try again.
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(timeoutStep)
 	}
 }
 

--- a/bolt_unix_solaris.go
+++ b/bolt_unix_solaris.go
@@ -12,9 +12,8 @@ import (
 
 // flock acquires an advisory lock on a file descriptor.
 func flock(db *DB, mode os.FileMode, exclusive bool, timeout time.Duration) error {
-	maxSleep := timeout - timeoutStep
 	var t time.Time
-	if maxSleep >= 0 {
+	if timeout != 0 {
 	        t = time.Now()
 	}
 	fd := db.file.Fd()
@@ -35,12 +34,12 @@ func flock(db *DB, mode os.FileMode, exclusive bool, timeout time.Duration) erro
 		}
 
 		// If we timed out then return an error.
-		if timeout != 0 && (maxSleep < 0 || time.Since(t) > maxSleep) {
+		if timeout != 0 && time.Since(t) > timeout - flockRetryTimeout {
 			return ErrTimeout
 		}
 
 		// Wait for a bit and try again.
-		time.Sleep(timeoutStep)
+		time.Sleep(flockRetryTimeout)
 	}
 }
 

--- a/bolt_unix_solaris.go
+++ b/bolt_unix_solaris.go
@@ -12,35 +12,35 @@ import (
 
 // flock acquires an advisory lock on a file descriptor.
 func flock(db *DB, mode os.FileMode, exclusive bool, timeout time.Duration) error {
+	maxSleep := timeout - timeoutStep
 	var t time.Time
+	if maxSleep >= 0 {
+	        t = time.Now()
+	}
+	fd := db.file.Fd()
+	var lockType int16
+	if exclusive {
+		lockType = syscall.F_WRLCK
+	} else {
+		lockType = syscall.F_RDLCK
+	}
 	for {
-		// If we're beyond our timeout then return an error.
-		// This can only occur after we've attempted a flock once.
-		if t.IsZero() {
-			t = time.Now()
-		} else if timeout > 0 && time.Since(t) > timeout {
-			return ErrTimeout
-		}
-		var lock syscall.Flock_t
-		lock.Start = 0
-		lock.Len = 0
-		lock.Pid = 0
-		lock.Whence = 0
-		lock.Pid = 0
-		if exclusive {
-			lock.Type = syscall.F_WRLCK
-		} else {
-			lock.Type = syscall.F_RDLCK
-		}
-		err := syscall.FcntlFlock(db.file.Fd(), syscall.F_SETLK, &lock)
+		// Attempt to obtain an exclusive lock.
+		lock := syscall.Flock_t{Type: lockType}
+		err := syscall.FcntlFlock(fd, syscall.F_SETLK, &lock)
 		if err == nil {
 			return nil
 		} else if err != syscall.EAGAIN {
 			return err
 		}
 
+		// If we timed out then return an error.
+		if timeout != 0 && (maxSleep < 0 || time.Since(t) > maxSleep) {
+			return ErrTimeout
+		}
+
 		// Wait for a bit and try again.
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(timeoutStep)
 	}
 }
 

--- a/bolt_windows.go
+++ b/bolt_windows.go
@@ -58,30 +58,32 @@ func flock(db *DB, mode os.FileMode, exclusive bool, timeout time.Duration) erro
 	}
 	db.lockfile = f
 
+	maxSleep := timeout - timeoutStep
 	var t time.Time
+	if maxSleep >= 0 {
+		t = time.Now()
+	}
+	fd := db.file.Fd()
+	var flag uint32 = flagLockFailImmediately
+	if exclusive {
+		flag |= flagLockExclusive
+	}
 	for {
-		// If we're beyond our timeout then return an error.
-		// This can only occur after we've attempted a flock once.
-		if t.IsZero() {
-			t = time.Now()
-		} else if timeout > 0 && time.Since(t) > timeout {
-			return ErrTimeout
-		}
-
-		var flag uint32 = flagLockFailImmediately
-		if exclusive {
-			flag |= flagLockExclusive
-		}
-
-		err := lockFileEx(syscall.Handle(db.lockfile.Fd()), flag, 0, 1, 0, &syscall.Overlapped{})
+		// Attempt to obtain an exclusive lock.
+		err := lockFileEx(syscall.Handle(fd), flag, 0, 1, 0, &syscall.Overlapped{})
 		if err == nil {
 			return nil
 		} else if err != errLockViolation {
 			return err
 		}
 
+		// If we timed oumercit then return an error.
+		if timeout != 0 && (maxSleep < 0 || time.Since(t) > maxSleep) {
+			return ErrTimeout
+		}
+
 		// Wait for a bit and try again.
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(timeoutStep)
 	}
 }
 

--- a/bolt_windows.go
+++ b/bolt_windows.go
@@ -58,10 +58,9 @@ func flock(db *DB, mode os.FileMode, exclusive bool, timeout time.Duration) erro
 	}
 	db.lockfile = f
 
-	maxSleep := timeout - timeoutStep
 	var t time.Time
-	if maxSleep >= 0 {
-		t = time.Now()
+	if timeout != 0 {
+	        t = time.Now()
 	}
 	fd := db.file.Fd()
 	var flag uint32 = flagLockFailImmediately
@@ -78,12 +77,12 @@ func flock(db *DB, mode os.FileMode, exclusive bool, timeout time.Duration) erro
 		}
 
 		// If we timed oumercit then return an error.
-		if timeout != 0 && (maxSleep < 0 || time.Since(t) > maxSleep) {
+		if timeout != 0 && time.Since(t) > timeout - flockRetryTimeout {
 			return ErrTimeout
 		}
 
 		// Wait for a bit and try again.
-		time.Sleep(timeoutStep)
+		time.Sleep(flockRetryTimeout)
 	}
 }
 

--- a/db.go
+++ b/db.go
@@ -40,6 +40,9 @@ const (
 // default page size for db is set to the OS page size.
 var defaultPageSize = os.Getpagesize()
 
+// The step used by the timeout mechanisms.
+const timeoutStep = 50 * time.Millisecond
+
 // DB represents a collection of buckets persisted to a file on disk.
 // All data access is performed through transactions which can be obtained through the DB.
 // All the functions on DB will return a ErrDatabaseNotOpen if accessed before Open() is called.

--- a/db.go
+++ b/db.go
@@ -40,8 +40,8 @@ const (
 // default page size for db is set to the OS page size.
 var defaultPageSize = os.Getpagesize()
 
-// The step used by the timeout mechanisms.
-const timeoutStep = 50 * time.Millisecond
+// The time elapsed between consecutive file locking attempts.
+const flockRetryTimeout = 50 * time.Millisecond
 
 // DB represents a collection of buckets persisted to a file on disk.
 // All data access is performed through transactions which can be obtained through the DB.


### PR DESCRIPTION
This is continuation of pull request #34 with same name, itself derived from https://github.com/boltdb/bolt/pull/494
I implemented the changes proposed by @heyitsanthony. I ended up with conflicts between my version derived from boltdb/bolt and the coreos/bbolt master. I resolved them and committed them into a clean branch based on coreos/bbolt master