### PR TITLE
db: return t.Rollback directly in the end of View function

### DIFF
--- a/db.go
+++ b/db.go
@@ -687,11 +687,7 @@ func (db *DB) View(fn func(*Tx) error) error {
 		return err
 	}
 
-	if err := t.Rollback(); err != nil {
-		return err
-	}
-
-	return nil
+	return t.Rollback()
 }
 
 // Batch calls fn as part of a batch. It behaves similar to Update,


### PR DESCRIPTION
Calling t.Rollback is a little bit misleading in the end of View function, since this tx has succeeded. What t.Rollback actually does here is closing this tx. So close tx directly.