### PR TITLE
Fix CLI tool print entire freelist. Add option to dump leaf element keys/value bytes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.test
 *.swp
 /bin/
+cmd/bolt/bolt


### PR DESCRIPTION
This includes two small fixes to the bolt CLI that we've needed a couple times in the past--

- Improve `bolt page` to print an accurate freelist.  Won't be relevant for dbs that don't persist the freelist, but still an improvement to have the command print the most accurate information available.
- Introduce `bolt page-item` to print a page item key and value. Had been handy for digging into data values at the bbolt level.