### PR TITLE
node: calculate total element size first in size/sizeLessThan

### DIFF
--- a/node.go
+++ b/node.go
@@ -39,9 +39,10 @@ func (n *node) minKeys() int {
 // size returns the size of the node after serialization.
 func (n *node) size() int {
 	sz, elsz := pageHeaderSize, n.pageElementSize()
+	sz += len(n.inodes) * elsz
 	for i := 0; i < len(n.inodes); i++ {
 		item := &n.inodes[i]
-		sz += elsz + len(item.key) + len(item.value)
+		sz += len(item.key) + len(item.value)
 	}
 	return sz
 }
@@ -51,9 +52,10 @@ func (n *node) size() int {
 // to know if it fits inside a certain page size.
 func (n *node) sizeLessThan(v int) bool {
 	sz, elsz := pageHeaderSize, n.pageElementSize()
+	sz += len(n.inodes) * elsz
 	for i := 0; i < len(n.inodes); i++ {
 		item := &n.inodes[i]
-		sz += elsz + len(item.key) + len(item.value)
+		sz += len(item.key) + len(item.value)
 		if sz >= v {
 			return false
 		}


### PR DESCRIPTION
Total element size can be calculated before loop. For `sizeLessThan` function, total element size of a large node may be larger than the given size, making determination process faster.