### PR TITLE
Panic if page provided to freelist.read is incorrect page type.

### DIFF
--- a/freelist.go
+++ b/freelist.go
@@ -233,6 +233,9 @@ func (f *freelist) freed(pgid pgid) bool {
 
 // read initializes the freelist from a freelist page.
 func (f *freelist) read(p *page) {
+	if (p.flags & freelistPageFlag) == 0 {
+		panic(fmt.Sprintf("invalid freelist page: %d, page type is %s", p.id, p.typ()))
+	}
 	// If the page.count is at the max uint16 value (64k) then it's considered
 	// an overflow and the size of the freelist is stored as the first element.
 	idx, count := 0, int(p.count)


### PR DESCRIPTION
Encountered this when debugging an issue found by https://github.com/coreos/etcd/pull/8813 CI tests.

This check simply aims to fail fast if ever bolt attempts to load a non-freelist page as a freelist, which has the potential to lead to data corruption.