### PR TITLE
Remove unnecessary if in batch handling

### DIFF
--- a/db.go
+++ b/db.go
@@ -802,9 +802,7 @@ retry:
 
 		// pass success, or bolt internal errors, to all callers
 		for _, c := range b.calls {
-			if c.err != nil {
-				c.err <- err
-			}
+			c.err <- err
 		}
 		break retry
 	}


### PR DESCRIPTION
This is safe, as the only place that creates call values always
explicitly sets err. It's a leftover from an earlier iteration of the
code.

(merged into boltdb, see https://github.com/boltdb/bolt/commit/32cc6eb1665364eddbb173120a40c37f1f3cfcb5)