### PR TITLE
bolt_ppc.go: define `var brokenUnaligned`

### DIFF
--- a/bolt_ppc.go
+++ b/bolt_ppc.go
@@ -7,3 +7,6 @@ const maxMapSize = 0x7FFFFFFF // 2GB
 
 // maxAllocSize is the size used when creating array pointers.
 const maxAllocSize = 0xFFFFFFF
+
+// Are unaligned load/stores broken on this arch?
+var brokenUnaligned = false


### PR DESCRIPTION
Trivial PR to make bbolt build on ppc. If this var is missing building on the ppc architecture fails.
