### PR TITLE
Improve node.Put func by delete redundant params

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -182,7 +182,7 @@ func (b *Bucket) CreateBucket(key []byte) (*Bucket, error) {
 
 	// Insert into node.
 	key = cloneBytes(key)
-	c.node().put(key, key, value, 0, bucketLeafFlag)
+	c.node().put(key, value, 0, bucketLeafFlag)
 
 	// Since subbuckets are not allowed on inline buckets, we need to
 	// dereference the inline page, if it exists. This will cause the bucket
@@ -299,7 +299,7 @@ func (b *Bucket) Put(key []byte, value []byte) error {
 
 	// Insert into node.
 	key = cloneBytes(key)
-	c.node().put(key, key, value, 0, 0)
+	c.node().put(key, value, 0, 0)
 
 	return nil
 }
@@ -556,7 +556,7 @@ func (b *Bucket) spill() error {
 		if flags&bucketLeafFlag == 0 {
 			panic(fmt.Sprintf("unexpected bucket header flag: %x", flags))
 		}
-		c.node().put([]byte(name), []byte(name), value, 0, bucketLeafFlag)
+		c.node().put([]byte(name), value, 0, bucketLeafFlag)
 	}
 
 	// Ignore if there's not a materialized root node.

--- a/node_test.go
+++ b/node_test.go
@@ -8,10 +8,10 @@ import (
 // Ensure that a node can insert a key/value.
 func TestNode_put(t *testing.T) {
 	n := &node{inodes: make(inodes, 0), bucket: &Bucket{tx: &Tx{meta: &meta{pgid: 1}}}}
-	n.put([]byte("baz"), []byte("baz"), []byte("2"), 0, 0)
-	n.put([]byte("foo"), []byte("foo"), []byte("0"), 0, 0)
-	n.put([]byte("bar"), []byte("bar"), []byte("1"), 0, 0)
-	n.put([]byte("foo"), []byte("foo"), []byte("3"), 0, leafPageFlag)
+	n.put([]byte("baz"), []byte("2"), 0, 0)
+	n.put([]byte("foo"), []byte("0"), 0, 0)
+	n.put([]byte("bar"), []byte("1"), 0, 0)
+	n.put([]byte("foo"), []byte("3"), 0, leafPageFlag)
 
 	if len(n.inodes) != 3 {
 		t.Fatalf("exp=3; got=%d", len(n.inodes))
@@ -71,9 +71,9 @@ func TestNode_read_LeafPage(t *testing.T) {
 func TestNode_write_LeafPage(t *testing.T) {
 	// Create a node.
 	n := &node{isLeaf: true, inodes: make(inodes, 0), bucket: &Bucket{tx: &Tx{db: &DB{}, meta: &meta{pgid: 1}}}}
-	n.put([]byte("susy"), []byte("susy"), []byte("que"), 0, 0)
-	n.put([]byte("ricki"), []byte("ricki"), []byte("lake"), 0, 0)
-	n.put([]byte("john"), []byte("john"), []byte("johnson"), 0, 0)
+	n.put([]byte("susy"), []byte("que"), 0, 0)
+	n.put([]byte("ricki"), []byte("lake"), 0, 0)
+	n.put([]byte("john"), []byte("johnson"), 0, 0)
 
 	// Write it to a page.
 	var buf [4096]byte
@@ -103,11 +103,11 @@ func TestNode_write_LeafPage(t *testing.T) {
 func TestNode_split(t *testing.T) {
 	// Create a node.
 	n := &node{inodes: make(inodes, 0), bucket: &Bucket{tx: &Tx{db: &DB{}, meta: &meta{pgid: 1}}}}
-	n.put([]byte("00000001"), []byte("00000001"), []byte("0123456701234567"), 0, 0)
-	n.put([]byte("00000002"), []byte("00000002"), []byte("0123456701234567"), 0, 0)
-	n.put([]byte("00000003"), []byte("00000003"), []byte("0123456701234567"), 0, 0)
-	n.put([]byte("00000004"), []byte("00000004"), []byte("0123456701234567"), 0, 0)
-	n.put([]byte("00000005"), []byte("00000005"), []byte("0123456701234567"), 0, 0)
+	n.put([]byte("00000001"), []byte("0123456701234567"), 0, 0)
+	n.put([]byte("00000002"), []byte("0123456701234567"), 0, 0)
+	n.put([]byte("00000003"), []byte("0123456701234567"), 0, 0)
+	n.put([]byte("00000004"), []byte("0123456701234567"), 0, 0)
+	n.put([]byte("00000005"), []byte("0123456701234567"), 0, 0)
 
 	// Split between 2 & 3.
 	n.split(100)
@@ -128,8 +128,8 @@ func TestNode_split(t *testing.T) {
 func TestNode_split_MinKeys(t *testing.T) {
 	// Create a node.
 	n := &node{inodes: make(inodes, 0), bucket: &Bucket{tx: &Tx{db: &DB{}, meta: &meta{pgid: 1}}}}
-	n.put([]byte("00000001"), []byte("00000001"), []byte("0123456701234567"), 0, 0)
-	n.put([]byte("00000002"), []byte("00000002"), []byte("0123456701234567"), 0, 0)
+	n.put([]byte("00000001"), []byte("0123456701234567"), 0, 0)
+	n.put([]byte("00000002"), []byte("0123456701234567"), 0, 0)
 
 	// Split.
 	n.split(20)
@@ -142,11 +142,11 @@ func TestNode_split_MinKeys(t *testing.T) {
 func TestNode_split_SinglePage(t *testing.T) {
 	// Create a node.
 	n := &node{inodes: make(inodes, 0), bucket: &Bucket{tx: &Tx{db: &DB{}, meta: &meta{pgid: 1}}}}
-	n.put([]byte("00000001"), []byte("00000001"), []byte("0123456701234567"), 0, 0)
-	n.put([]byte("00000002"), []byte("00000002"), []byte("0123456701234567"), 0, 0)
-	n.put([]byte("00000003"), []byte("00000003"), []byte("0123456701234567"), 0, 0)
-	n.put([]byte("00000004"), []byte("00000004"), []byte("0123456701234567"), 0, 0)
-	n.put([]byte("00000005"), []byte("00000005"), []byte("0123456701234567"), 0, 0)
+	n.put([]byte("00000001"), []byte("0123456701234567"), 0, 0)
+	n.put([]byte("00000002"), []byte("0123456701234567"), 0, 0)
+	n.put([]byte("00000003"), []byte("0123456701234567"), 0, 0)
+	n.put([]byte("00000004"), []byte("0123456701234567"), 0, 0)
+	n.put([]byte("00000005"), []byte("0123456701234567"), 0, 0)
 
 	// Split.
 	n.split(4096)


### PR DESCRIPTION
oldKey and newKey always have same value. If oldKey is different with newKey, inode insert index of newKey is wrong. 

With oldKey and newKey both exist,  making it hard to understand.