### PR TITLE
Close waits for the transactions to finish

### DIFF
--- a/db.go
+++ b/db.go
@@ -441,7 +441,7 @@ func (db *DB) init() error {
 }
 
 // Close releases all database resources.
-// All transactions must be closed before closing the database.
+// It will block waiting for any open transactions to finish before closing the database and returning.
 func (db *DB) Close() error {
 	db.rwlock.Lock()
 	defer db.rwlock.Unlock()

--- a/db.go
+++ b/db.go
@@ -441,7 +441,8 @@ func (db *DB) init() error {
 }
 
 // Close releases all database resources.
-// It will block waiting for any open transactions to finish before closing the database and returning.
+// It will block waiting for any open transactions to finish
+// before closing the database and returning.
 func (db *DB) Close() error {
 	db.rwlock.Lock()
 	defer db.rwlock.Unlock()


### PR DESCRIPTION
DB.Close() actually waits for the transactions to finish now, since the PR 377.
https://github.com/boltdb/bolt/pull/377

This PR updates the documentation.