### PR TITLE
Madvise optional

### DIFF
--- a/bolt_unix.go
+++ b/bolt_unix.go
@@ -56,7 +56,9 @@ func mmap(db *DB, sz int) error {
 	}
 
 	// Advise the kernel that the mmap is accessed randomly.
-	if err := madvise(b, syscall.MADV_RANDOM); err != nil {
+	err = madvise(b, syscall.MADV_RANDOM)
+	if err != nil && err != syscall.ENOSYS {
+		// Ignore not implemented error in kernel because it still works.
 		return fmt.Errorf("madvise: %s", err)
 	}
 


### PR DESCRIPTION
OpenWRT Linux kernel doesn't support madvise syscall. It always returns "function not implemented" error, but it still works fine. This should be optional check.