### PR TITLE
db.go: clean up file descriptor on init/read failures

### DIFF
--- a/db.go
+++ b/db.go
@@ -239,6 +239,7 @@ func Open(path string, mode os.FileMode, options *Options) (*DB, error) {
 				db.pageSize = int(m.pageSize)
 			}
 		} else {
+			_ = db.close()
 			return nil, ErrInvalid
 		}
 	}

--- a/db.go
+++ b/db.go
@@ -213,10 +213,13 @@ func Open(path string, mode os.FileMode, options *Options) (*DB, error) {
 
 	// Initialize the database if it doesn't exist.
 	if info, err := db.file.Stat(); err != nil {
+		_ = db.close()
 		return nil, err
 	} else if info.Size() == 0 {
 		// Initialize new files with meta pages.
 		if err := db.init(); err != nil {
+			// clean up file descriptor on initialization fail
+			_ = db.close()
 			return nil, err
 		}
 	} else {


### PR DESCRIPTION
Fixes an issue where failing to open a non-existent database in ReadOnly
mode would make you unable to properly initialize it in ReadWrite mode
afterwards due to a hanging lock.

https://github.com/boltdb/bolt/pull/725

/cc @xiang90 @heyitsanthony